### PR TITLE
update contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,68 @@
 
 # Contribution guidelines
 
-In order to make sure that everyone involved in the project have good experience contributing, we have some guidelines which we would like you to follow:
-
-- Do you have a suggestion how to improve the project or you found a bug? Create a Github issue with that. Don't be afraid of writing down your ideas! Make sure you describe it as best as you can and add a schema / image / gif if it helps you to express yourself better. Try to keep the context small as well. 
-- Do you have a question about an existing issue? Ask creator by talking to her directly or by adding a comment in the issue. We are all learning here, so questions are always welcome!
-- You don't know where to start? Assign an issue to you and start working on it :) For that, we would advise to:
-  - Create a new branch locally with the issue number + title
-  - Try to solve the issue. Try to name things clearly (again, feel free to discuss it with someone if needed) and take your time to solve your problem, we are not in a rush :)
-  - Do regular commits of your development
-  - Add unit tests :D
-  - Push your changes to your branch at the end of each hack night. If you are not finished, add a description of what's done / what's missing so that someone can pick it up from there next time in case you can't attend
-  - Create a pull request (make sure all tests pass before). Describe in the pull request what you have done and what problem your solution solves
-- Are you a reviewer?
-  - Verify that all tests pass
-  - Check if the pull request solves the problem
-  - Check code readability and add comments if you have some suggestions or you don't understand something
+In order to make sure that everyone involved in the project has a good experience contributing, we have some guidelines which we would like you to follow.
+The most important ones:
 - Have fun!
+- Remember we are all working on this to learn something
+
+### Creating Issues
+
+Do you have a suggestion how to improve the project or you found a bug? Create a Github issue with that.
+Don't be afraid of writing down your ideas!
+Make sure you describe it as best as you can and add a schema / image / gif if it helps you to express yourself better.
+Try to keep the context small as well.
+
+Do you have a question about an existing issue?
+Ask the creator by talking to her directly (e.g. on our slack) or by adding a comment in the issue.
+We are all learning here, so questions are always welcome!
+
+##### Tags
+
+In addition to the default labels from github we have a few of our own:
+
+- `advanced`: to indicate that an issue is not suitable for beginners
+- `documentation`: to indicate that an issue is not directly related to the source code, but about adding some documentation
+
+An overview of the default labels and what they mean can be found in the [github docs](https://help.github.com/articles/about-labels/)
+
+The important ones are:
+- `good first issue`: For tasks that are note too complex and don't require extensive knowledge of the project
+- `help wanted`: To indicate that the maintainers would be really happy if someone worked on this
+
+
+### Working on Issues
+
+If you find an issue that you would like to work on, we have a few steps that you should follow to make sure there is no overlap between people working on the same things.
+
+1. Assign yourself to this issue, so that others now what you are doing.
+2. Create a fork of the repo and create a feature branch there. The branch name should ideally be descriptive and contain the issue number.
+3. Try to solve the issue. Do regular commits and add descriptive commit messages.
+4. If you think you are done, got to github and create a pull request (PR) from your fork to this repo.
+5. Add a meaningful description to your PR and reference the issue number if there is one. Describe what you did and how this solves the issue.
+6. Wait for a review of your PR and be ready to make adjustments if needed.
+7. If the reviewer approves your PR, your changes will be merged into the main repo. The issue can now be closed.
+
+
+### Pull Request Reviews
+
+At the moment only admins can merge PRs, but adding reviews and comments to PRs is open to everybody.
+If you want to review a PR:
+- make sure the code works
+- if there are tests, make sure they pass
+- Does the solution solve the problem?
+- Is the code readable?
+- Feel free to add comments with questions if you do not understand something or suggest improvements.
+
+Always keep in mind we are all here to learn, so be constructive and try to explain as much as you can.
+
+### Communication
+
+We use github issues to keep track of the things we want to do on this project.
+Feel free to add comments to issues if you have a different opinion or if you have a suggestion.
+
+We also use the WWCode-hacknights slack.
+There are dedicated channels for discussing this project: `#issues-explorer-fe` and `#issues-explorer-be`.
+
+If you want to join us on slack, use this [signup link](https://join.slack.com/t/wwcode-hacknights/shared_invite/enQtMzQwNTg0NTIwMTYyLWJmYjg1YzFlM2RlMjEzNTNlNjQ3OTk5NGNhMGM4NjgxYzllMmQ4Y2ZiYjBiYWIyZjM2YWQ2NzYwYThhNjNiOWU).
+

--- a/issues-berlin/README.md
+++ b/issues-berlin/README.md
@@ -56,7 +56,7 @@ If your port 3000 is already blocked by another app, this will not work because 
 
 ## Contributing
 
-Please review our [contributing guidelines](CONTRIBUTING.md) and enjoy collaboration!
+Please review our [contributing guidelines](https://github.com/WomenWhoCode/berlin-issues-explorer-fe/blob/master/CONTRIBUTING.md) and enjoy collaboration!
 For starters have a look at the open [issues](https://github.com/WomenWhoCode/berlin-issues-explorer-fe/issues).
 
 


### PR DESCRIPTION
Related to #16:
- fixed the broken link to the contribution guidelines in the `issues-berlin/README.md`.
- Added more detail to the contribution guidelines like tags we use
